### PR TITLE
[nasa/nos3#427] radio checkout

### DIFF
--- a/fsw/public_inc/hwlib.h
+++ b/fsw/public_inc/hwlib.h
@@ -37,7 +37,11 @@ ivv-itc@lists.nasa.gov
 /************************************************************************
 ** Outside of cFS build
 *************************************************************************/
-#ifndef OS_SUCCESS
+#ifdef OS_SUCCESS
+    // Inside cFS
+    #include "cfe_endian.h"
+#else
+    // Outside cFS
     #pragma GCC diagnostic ignored "-Wall"
     #pragma GCC diagnostic warning "-Wunused-value"
     #define OS_printf           printf

--- a/fsw/stubs/libtrq.c
+++ b/fsw/stubs/libtrq.c
@@ -112,5 +112,5 @@ int32_t trq_command(trq_info_t *device, uint8_t percent_high, bool pos_dir)
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 void trq_close(trq_info_t* device)
 {
-    return TRQ_SUCCESS;
+    return;
 }


### PR DESCRIPTION
Updates to hwlib so it can properly replace and allow the use of the cfe_endian conversion macros in radio device.